### PR TITLE
[fee_amount-error] fee_amount and fee_mint Deprecated and switch to optional

### DIFF
--- a/jupiter-swap-api-client/src/route_plan_with_metadata.rs
+++ b/jupiter-swap-api-client/src/route_plan_with_metadata.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use solana_sdk::pubkey::Pubkey;
 
-use crate::serde_helpers::field_as_string;
+use crate::serde_helpers::{field_as_string, option_field_as_string};
 
 /// Topologically sorted DAG with additional metadata for rendering
 pub type RoutePlanWithMetadata = Vec<RoutePlanStep>;
@@ -29,8 +29,12 @@ pub struct SwapInfo {
     /// An estimation of the output amount into the AMM
     #[serde(with = "field_as_string")]
     pub out_amount: u64,
-    #[serde(with = "field_as_string")]
-    pub fee_amount: u64,
-    #[serde(with = "field_as_string")]
-    pub fee_mint: Pubkey,
+    /// Deprecated: This field is no longer returned by Jupiter API (or returns 0)
+    /// The fee is already factored into out_amount
+    #[serde(default, with = "option_field_as_string")]
+    pub fee_amount: Option<u64>,
+    /// Deprecated: This field is no longer returned by Jupiter API (or returns input mint)
+    /// The fee is already factored into out_amount
+    #[serde(default, with = "option_field_as_string")]
+    pub fee_mint: Option<Pubkey>,
 }

--- a/jupiter-swap-api-client/src/serde_helpers/option_field_as_string.rs
+++ b/jupiter-swap-api-client/src/serde_helpers/option_field_as_string.rs
@@ -1,4 +1,4 @@
-use {serde::Serialize, serde::Serializer};
+use {serde::{Deserialize, Deserializer, Serialize, Serializer}, std::str::FromStr};
 
 pub fn serialize<T, S>(t: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>
 where
@@ -9,5 +9,21 @@ where
         t.to_string().serialize(serializer)
     } else {
         serializer.serialize_none()
+    }
+}
+
+pub fn deserialize<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    T: FromStr,
+    T::Err: std::fmt::Display,
+    D: Deserializer<'de>,
+{
+    let s: Option<String> = Option::deserialize(deserializer)?;
+    match s {
+        Some(s) => s
+            .parse::<T>()
+            .map(Some)
+            .map_err(serde::de::Error::custom),
+        None => Ok(None),
     }
 }


### PR DESCRIPTION
https://dev.jup.ag/updates#deprecate-feeamount-and-feemint-fields-in-swapinfo